### PR TITLE
feat(consensus): Remove slots from general exporter

### DIFF
--- a/pkg/exporter/consensus/jobs/beacon.go
+++ b/pkg/exporter/consensus/jobs/beacon.go
@@ -242,6 +242,10 @@ func (b *Beacon) GetFinality(ctx context.Context, stateID string) error {
 }
 
 func (b *Beacon) handleSingleBlock(blockID string, block *spec.VersionedSignedBeaconBlock) error {
+	if block == nil {
+		return errors.New("block is nil")
+	}
+
 	if b.currentVersion != block.Version.String() {
 		b.Transactions.Reset()
 		b.Slashings.Reset()

--- a/pkg/exporter/consensus/metrics.go
+++ b/pkg/exporter/consensus/metrics.go
@@ -49,7 +49,6 @@ func NewMetrics(client eth2client.Service, ap api.ConsensusClient, log logrus.Fi
 		eventMetrics:   jobs.NewEventJob(client, ap, log, namespace, constLabels),
 	}
 
-	prometheus.MustRegister(m.generalMetrics.Slots)
 	prometheus.MustRegister(m.generalMetrics.NodeVersion)
 	prometheus.MustRegister(m.generalMetrics.Peers)
 


### PR DESCRIPTION
These metrics were already covered by the `beacon` exporter. Also includes a little panic fix.