### PR TITLE
feat(consensus): Reduce polling frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,15 @@ Naturally this means that the exporter is limited to metrics that are exposed by
 ## Usage
 
 ```
-A tool to report the state of ethereum nodes
+A tool to export the state of ethereum nodes
 
 Usage:
   ethereum-metrics-exporter [flags]
-  ethereum-metrics-exporter [command]
-
-Available Commands:
-  completion  Generate the autocompletion script for the specified shell
-  help        Help about any command
-  serve       Run a metrics server and poll the configured clients.
 
 Flags:
       --config string                   config file (default is $HOME/.ethereum-metrics-exporter.yaml)
       --consensus-url string            (optional) URL to the consensus node
+      --execution-modules strings       (optional) execution modules that are enabled on the node
       --execution-url string            (optional) URL to the execution node
   -h, --help                            help for ethereum-metrics-exporter
       --metrics-port int                Port to serve Prometheus metrics on (default 9090)

--- a/pkg/exporter/consensus/jobs/event.go
+++ b/pkg/exporter/consensus/jobs/event.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
 	v1 "github.com/attestantio/go-eth2-client/api/v1"
@@ -12,8 +13,11 @@ import (
 
 // Event reports event counts.
 type Event struct {
-	log   logrus.FieldLogger
-	Count prometheus.CounterVec
+	log                logrus.FieldLogger
+	Count              prometheus.CounterVec
+	TimeSinceLastEvent prometheus.Gauge
+
+	LastEventTime time.Time
 }
 
 const (
@@ -38,6 +42,15 @@ func NewEventJob(client eth2client.Service, ap api.ConsensusClient, log logrus.F
 				"name",
 			},
 		),
+		TimeSinceLastEvent: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "time_since_last_subscription_event_ms",
+				Help:        "The amount of time since the last subscription event (in milliseconds).",
+				ConstLabels: constLabels,
+			},
+		),
+		LastEventTime: time.Now(),
 	}
 }
 
@@ -45,8 +58,23 @@ func (b *Event) Name() string {
 	return NameEvent
 }
 
-func (b *Event) Start(ctx context.Context) {}
+func (b *Event) Start(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second * 1):
+			b.tick(ctx)
+		}
+	}
+}
+
+func (b *Event) tick(ctx context.Context) {
+	b.TimeSinceLastEvent.Set(float64(time.Since(b.LastEventTime).Milliseconds()))
+}
 
 func (b *Event) HandleEvent(ctx context.Context, event *v1.Event) {
 	b.Count.WithLabelValues(event.Topic).Inc()
+	b.LastEventTime = time.Now()
+	b.TimeSinceLastEvent.Set(0)
 }

--- a/pkg/exporter/consensus/jobs/event.go
+++ b/pkg/exporter/consensus/jobs/event.go
@@ -69,6 +69,7 @@ func (b *Event) Start(ctx context.Context) {
 	}
 }
 
+//nolint:unparam // ctx will probably be used in the future
 func (b *Event) tick(ctx context.Context) {
 	b.TimeSinceLastEvent.Set(float64(time.Since(b.LastEventTime).Milliseconds()))
 }


### PR DESCRIPTION
- Rely on events entirely for following the consensus slots & finality checkpoints
- Added a new metric that reports when the last subscription event we received was (roughly)
- Added reconnect logic to the subscription in case the CL is restarted