### PR TITLE
feat(consensus): Export state roots as a bounded hash range

### DIFF
--- a/pkg/exporter/consensus/jobs/beacon.go
+++ b/pkg/exporter/consensus/jobs/beacon.go
@@ -36,7 +36,7 @@ const (
 	NameBeacon = "beacon"
 	// NumRootHashShards defines the range of values that the *hash metrics are moduloed by. That is to say,
 	// this number defines the value range of those metrics from 0 -> NumRootHashShards.
-	NumRootHashShards = 4096
+	NumRootHashShards = 65536
 )
 
 // NewBeacon creates a new Beacon instance.

--- a/pkg/exporter/consensus/jobs/beacon_block.go
+++ b/pkg/exporter/consensus/jobs/beacon_block.go
@@ -49,3 +49,42 @@ func NewBeaconBlockFromBellatrix(block *spec.VersionedSignedBeaconBlock) BeaconB
 		Slot:              uint64(block.Bellatrix.Message.Slot),
 	}
 }
+
+func GetDepositCountsFromBeaconBlock(block *spec.VersionedSignedBeaconBlock) int {
+	switch block.Version {
+	case spec.DataVersionPhase0:
+		return len(block.Phase0.Message.Body.Deposits)
+	case spec.DataVersionAltair:
+		return len(block.Altair.Message.Body.Deposits)
+	case spec.DataVersionBellatrix:
+		return len(block.Bellatrix.Message.Body.Deposits)
+	default:
+		return 0
+	}
+}
+
+func GetVoluntaryExitsFromBeaconBlock(block *spec.VersionedSignedBeaconBlock) int {
+	switch block.Version {
+	case spec.DataVersionPhase0:
+		return len(block.Phase0.Message.Body.VoluntaryExits)
+	case spec.DataVersionAltair:
+		return len(block.Altair.Message.Body.VoluntaryExits)
+	case spec.DataVersionBellatrix:
+		return len(block.Bellatrix.Message.Body.VoluntaryExits)
+	default:
+		return 0
+	}
+}
+
+func GetTransactionsCountFromBeaconBlock(block *spec.VersionedSignedBeaconBlock) int {
+	switch block.Version {
+	case spec.DataVersionPhase0:
+		return 0
+	case spec.DataVersionAltair:
+		return 0
+	case spec.DataVersionBellatrix:
+		return len(block.Bellatrix.Message.Body.ExecutionPayload.Transactions)
+	default:
+		return 0
+	}
+}

--- a/pkg/exporter/consensus/metrics.go
+++ b/pkg/exporter/consensus/metrics.go
@@ -96,6 +96,8 @@ func NewMetrics(client eth2client.Service, ap api.ConsensusClient, log logrus.Fi
 	prometheus.MustRegister(m.beaconMetrics.FinalityCheckpoints)
 	prometheus.MustRegister(m.beaconMetrics.ReOrgs)
 	prometheus.MustRegister(m.beaconMetrics.ReOrgDepth)
+	prometheus.MustRegister(m.beaconMetrics.FinalityCheckpointHash)
+	prometheus.MustRegister(m.beaconMetrics.HeadSlotHash)
 
 	prometheus.MustRegister(m.eventMetrics.Count)
 	prometheus.MustRegister(m.eventMetrics.TimeSinceLastEvent)


### PR DESCRIPTION
This change adds two new metrics:

- `eth_con_beacon_finality_checkpoint_hash` following the head checkpoints for finalized/justified/previous_justified
- `eth_con_beacon_head_slot_hash` following the head slot

These metrics observe the state roots, and **consistently** convert them in to an integer between 0 and 65536. These metrics can then be used to observe which chain a beacon node is following by comparing this value at the current time to other nodes. 

To work around scrape intervals, a query like this can be used to try and avoid noise:
`max(eth_con_beacon_head_slot_hash)[1m]`.
