### PR TITLE
feat(pair): Add consensus_mechanism metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ethereum-metrics-exporter
+test_config.yaml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,6 @@ linters:
     - tparallel
     - typecheck
     - unconvert
-    - unparam
     - varcheck
     - whitespace
     - wsl

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -8,6 +8,8 @@ type Config struct {
 	Consensus ConsensusNode `yaml:"consensus"`
 	// DiskUsage determines if the disk usage metrics should be exported.
 	DiskUsage DiskUsage `yaml:"diskUsage"`
+	// Pair determines if the pair metrics should be exported.
+	Pair PairConfig `yaml:"pair"`
 }
 
 // ConsensusNode represents a single ethereum consensus client.
@@ -31,6 +33,11 @@ type DiskUsage struct {
 	Directories []string `yaml:"directories"`
 }
 
+// PairConfig holds the config for a Pair of Execution and Consensus Clients
+type PairConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
 // DefaultConfig represents a sane-default configuration.
 func DefaultConfig() *Config {
 	return &Config{
@@ -48,6 +55,9 @@ func DefaultConfig() *Config {
 		DiskUsage: DiskUsage{
 			Enabled:     false,
 			Directories: []string{},
+		},
+		Pair: PairConfig{
+			Enabled: true,
 		},
 	}
 }

--- a/pkg/exporter/pair/networks.go
+++ b/pkg/exporter/pair/networks.go
@@ -1,0 +1,33 @@
+package pair
+
+type ConsensusMechanism struct {
+	Name     string
+	Short    string
+	Priority float64
+}
+
+var (
+	ProofOfWork = ConsensusMechanism{
+		Name:     "Proof of Work",
+		Short:    "PoW",
+		Priority: 1,
+	}
+	ProofOfAuthority = ConsensusMechanism{
+		Name:     "Proof of Authority",
+		Short:    "PoA",
+		Priority: 2,
+	}
+	ProofOfStake = ConsensusMechanism{
+		Name:     "Proof of Stake",
+		Short:    "PoS",
+		Priority: 3,
+	}
+)
+
+var DefaultConsensusMechanism = ProofOfWork
+
+var (
+	DefaultNetworkConsensusMechanism = map[uint64]ConsensusMechanism{
+		5: ProofOfAuthority,
+	}
+)

--- a/pkg/exporter/pair/pair.go
+++ b/pkg/exporter/pair/pair.go
@@ -110,7 +110,7 @@ func (p *pair) StartAsync(ctx context.Context) {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(time.Second * 15):
+			case <-time.After(time.Second * 5):
 				if !p.bootstrapped {
 					if err := p.Bootstrap(ctx); err != nil {
 						continue

--- a/pkg/exporter/pair/pair.go
+++ b/pkg/exporter/pair/pair.go
@@ -1,0 +1,235 @@
+package pair
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/http"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/onrik/ethrpc"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cast"
+)
+
+// Metrics reports pair metrics
+type Metrics interface {
+	// StartAsync starts the disk usage metrics collection.
+	StartAsync(ctx context.Context)
+}
+
+type pair struct {
+	log logrus.FieldLogger
+
+	consensusMechanism *prometheus.GaugeVec
+
+	executionClient *ethclient.Client
+	consensusClient eth2client.Service
+	ethrpcClient    *ethrpc.EthRPC
+	bootstrapped    bool
+	consensusURL    string
+	executionURL    string
+
+	totalDifficulty         *big.Int
+	terminalTotalDifficulty *big.Int
+	networkID               *big.Int
+
+	networkIDFetchedAt time.Time
+	ttdFetchedAt       time.Time
+	tdFetchedAt        time.Time
+}
+
+// NewMetrics returns a new Metrics instance.
+func NewMetrics(ctx context.Context, log logrus.FieldLogger, namespace, consensusURL, executionURL string) (Metrics, error) {
+	p := &pair{
+		log: log,
+
+		executionURL: executionURL,
+		consensusURL: consensusURL,
+
+		consensusClient: nil,
+		executionClient: nil,
+		ethrpcClient:    nil,
+
+		bootstrapped: false,
+
+		consensusMechanism: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "consensus_mechanism",
+				Help:      "Consensus mechanism used",
+			},
+			[]string{
+				"consensus_mechanism",
+				"consensus_mechanism_short",
+			},
+		),
+
+		totalDifficulty:         big.NewInt(0),
+		terminalTotalDifficulty: big.NewInt(0),
+	}
+
+	prometheus.MustRegister(p.consensusMechanism)
+
+	return p, nil
+}
+
+func (p *pair) Bootstrap(ctx context.Context) error {
+	consenusClient, err := http.New(ctx,
+		http.WithAddress(p.consensusURL),
+		http.WithLogLevel(zerolog.Disabled),
+	)
+	if err != nil {
+		return err
+	}
+
+	p.consensusClient = consenusClient
+
+	executionClient, err := ethclient.Dial(p.executionURL)
+	if err != nil {
+		return err
+	}
+
+	p.executionClient = executionClient
+
+	p.ethrpcClient = ethrpc.New(p.executionURL)
+
+	p.bootstrapped = true
+
+	return nil
+}
+
+func (p *pair) StartAsync(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Second * 15):
+				if !p.bootstrapped {
+					if err := p.Bootstrap(ctx); err != nil {
+						continue
+					}
+				}
+
+				if time.Since(p.ttdFetchedAt) > 5*time.Minute {
+					if err := p.fetchTerminalTotalDifficulty(ctx); err != nil {
+						p.log.WithError(err).Error("Failed to fetch terminal total difficulty")
+					}
+				}
+
+				if time.Since(p.tdFetchedAt) > 12*time.Second {
+					if err := p.fetchTotalDifficulty(ctx); err != nil {
+						p.log.WithError(err).Error("Failed to fetch total difficulty")
+					}
+				}
+
+				if time.Since(p.networkIDFetchedAt) > 1*time.Minute {
+					if err := p.fetchNetworkID(ctx); err != nil {
+						p.log.WithError(err).Error("Failed to fetch network ID")
+					}
+				}
+
+				if err := p.deriveConsensusMechanism(ctx); err != nil {
+					p.log.WithError(err).Error("Failed to derive consensus mechanism")
+				}
+			}
+		}
+	}()
+}
+
+func (p *pair) fetchTotalDifficulty(ctx context.Context) error {
+	mostRecentBlockNumber, err := p.executionClient.BlockNumber(ctx)
+	if err != nil {
+		return err
+	}
+
+	block, err := p.ethrpcClient.EthGetBlockByNumber(int(mostRecentBlockNumber), false)
+	if err != nil {
+		return err
+	}
+
+	p.totalDifficulty = &block.TotalDifficulty
+
+	p.tdFetchedAt = time.Now()
+
+	return nil
+}
+
+func (p *pair) fetchNetworkID(ctx context.Context) error {
+	networkID, err := p.executionClient.NetworkID(ctx)
+	if err != nil {
+		return err
+	}
+
+	p.networkID = networkID
+
+	p.networkIDFetchedAt = time.Now()
+
+	return nil
+}
+
+func (p *pair) fetchTerminalTotalDifficulty(ctx context.Context) error {
+	provider, isProvider := p.consensusClient.(eth2client.SpecProvider)
+	if !isProvider {
+		return errors.New("client does not implement eth2client.SpecProvider")
+	}
+
+	spec, err := provider.Spec(ctx)
+	if err != nil {
+		return err
+	}
+
+	terminalTotalDifficulty, exists := spec["TERMINAL_TOTAL_DIFFICULTY"]
+	if !exists {
+		return errors.New("TERMINAL_TOTAL_DIFFICULTY not found in spec")
+	}
+
+	ttd := cast.ToString(fmt.Sprintf("%v", terminalTotalDifficulty))
+
+	asBigInt, success := big.NewInt(0).SetString(ttd, 10)
+	if !success {
+		return errors.New("TERMINAL_TOTAL_DIFFICULTY not a valid integer")
+	}
+
+	p.terminalTotalDifficulty = asBigInt
+
+	p.ttdFetchedAt = time.Now()
+
+	return nil
+}
+
+func (p *pair) deriveConsensusMechanism(ctx context.Context) error {
+	if p.totalDifficulty == big.NewInt(0) {
+		return errors.New("total difficulty not fetched")
+	}
+
+	if p.terminalTotalDifficulty == big.NewInt(0) {
+		return errors.New("terminal total difficulty not fetched")
+	}
+
+	if p.networkID == big.NewInt(0) {
+		return errors.New("network ID not fetched")
+	}
+
+	consensusMechanism := DefaultConsensusMechanism
+
+	// Support networks like Goerli that use Proof of Authority as the default consensus mechanism.
+	if value, exists := DefaultNetworkConsensusMechanism[p.networkID.Uint64()]; exists {
+		consensusMechanism = value
+	}
+
+	if p.totalDifficulty.Cmp(p.terminalTotalDifficulty) >= 0 {
+		consensusMechanism = ProofOfStake
+	}
+
+	p.consensusMechanism.Reset()
+	p.consensusMechanism.WithLabelValues(consensusMechanism.Name, consensusMechanism.Short).Set(consensusMechanism.Priority)
+
+	return nil
+}

--- a/pkg/exporter/pair/pair.go
+++ b/pkg/exporter/pair/pair.go
@@ -117,7 +117,7 @@ func (p *pair) StartAsync(ctx context.Context) {
 					}
 				}
 
-				if time.Since(p.ttdFetchedAt) > 5*time.Minute {
+				if time.Since(p.ttdFetchedAt) > 15*time.Minute {
 					if err := p.fetchTerminalTotalDifficulty(ctx); err != nil {
 						p.log.WithError(err).Error("Failed to fetch terminal total difficulty")
 					}
@@ -129,7 +129,7 @@ func (p *pair) StartAsync(ctx context.Context) {
 					}
 				}
 
-				if time.Since(p.networkIDFetchedAt) > 1*time.Minute {
+				if time.Since(p.networkIDFetchedAt) > 15*time.Minute {
 					if err := p.fetchNetworkID(ctx); err != nil {
 						p.log.WithError(err).Error("Failed to fetch network ID")
 					}


### PR DESCRIPTION
Adds a new exporter job, `pair`, which requires both the execution & consensus modules to be enabled. There is a single metric exported:

```
eth_pair_consensus_mechanism{consensus_mechanism="Proof of Stake",consensus_mechanism_short="PoS"} 3
```

