### PR TITLE
chore: run docker build on PRs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
     tags:
       - 'v*.*.*'
+  pull_request:
 
 jobs:
   docker:
@@ -39,7 +40,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
This change will run the docker build (without publishing) so that we can make sure that it works. 