### PR TITLE
fix(execution): Fix panic when nil block is returned

### DIFF
--- a/pkg/exporter/consensus/jobs/beacon.go
+++ b/pkg/exporter/consensus/jobs/beacon.go
@@ -260,7 +260,7 @@ func (b *Beacon) handleBlockInserted(ctx context.Context, event *beacon.BlockIns
 		return err
 	}
 
-	// nolint:gocritic // False positive
+	//nolint:gocritic // False positive
 	if err = b.handleSingleBlock("head", timedBlock.Block); err != nil {
 		return err
 	}

--- a/pkg/exporter/consensus/jobs/spec.go
+++ b/pkg/exporter/consensus/jobs/spec.go
@@ -290,16 +290,16 @@ func (s *Spec) observeSpec(ctx context.Context, spec *state.Spec) error {
 	s.SafeSlotsToUpdateJustified.Set(float64(spec.SafeSlotsToUpdateJustified))
 	s.DepositChainID.Set(float64(spec.DepositChainID))
 	s.MaxValidatorsPerCommittee.Set(float64(spec.MaxValidatorsPerCommittee))
-	// nolint:unconvert // false positive
+	//nolint:unconvert // false positive
 	s.SecondsPerEth1Block.Set(float64(spec.SecondsPerEth1Block.Seconds()))
 	s.BaseRewardFactor.Set(float64(spec.BaseRewardFactor))
 	s.EpochsPerSyncCommitteePeriod.Set(float64(spec.EpochsPerSyncCommitteePeriod))
 	s.EffectiveBalanceIncrement.Set(float64(spec.EffectiveBalanceIncrement))
 	s.MaxAttestations.Set(float64(spec.MaxAttestations))
 	s.MinSyncCommitteeParticipants.Set(float64(spec.MinSyncCommitteeParticipants))
-	// nolint:unconvert // false positive
+	//nolint:unconvert // false positive
 	s.GenesisDelay.Set(float64(spec.GenesisDelay.Seconds()))
-	// nolint:unconvert // false positive
+	//nolint:unconvert // false positive
 	s.SecondsPerSlot.Set(float64(spec.SecondsPerSlot.Seconds()))
 	s.MaxEffectiveBalance.Set(float64(spec.MaxEffectiveBalance))
 	s.MaxDeposits.Set(float64(spec.MaxDeposits))

--- a/pkg/exporter/execution/jobs/block.go
+++ b/pkg/exporter/execution/jobs/block.go
@@ -223,6 +223,10 @@ func (b *BlockMetrics) getHeadBlockStats(ctx context.Context) error {
 		return err
 	}
 
+	if block == nil {
+		return errors.New("block is nil")
+	}
+
 	b.HeadGasUsed.Set(float64(block.GasUsed))
 	b.HeadGasLimit.Set(float64(block.GasLimit))
 	b.HeadBlockSize.Set(float64(block.Size))


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xe8 pc=0xd1f789]

goroutine 90 [running]:
github.com/samcm/ethereum-metrics-exporter/pkg/exporter/execution/jobs.(*BlockMetrics).getHeadBlockStats(0xc0003acc18, {0x11907b0, 0xc00012e000})
	/src/pkg/exporter/execution/jobs/block.go:226 +0x189
github.com/samcm/ethereum-metrics-exporter/pkg/exporter/execution/jobs.(*BlockMetrics).tick(0xc0003acc18, {0x11907b0?, 0xc00012e000?})
	/src/pkg/exporter/execution/jobs/block.go:202 +0x2c
github.com/samcm/ethereum-metrics-exporter/pkg/exporter/execution/jobs.(*BlockMetrics).Start(0x0?, {0x11907b0, 0xc00012e000})
	/src/pkg/exporter/execution/jobs/block.go:196 +0x4e
created by github.com/samcm/ethereum-metrics-exporter/pkg/exporter/execution.(*metrics).StartAsync
	/src/pkg/exporter/execution/metrics.go:146 +0x30c
```