### PR TITLE
Feat(consensus): Peer client detection

### DIFF
--- a/pkg/exporter/consensus/api/types/agents.go
+++ b/pkg/exporter/consensus/api/types/agents.go
@@ -1,0 +1,60 @@
+package types
+
+import (
+	"strings"
+)
+
+type Agent string
+
+const (
+	AgentUnknown    Agent = "unknown"
+	AgentLighthouse Agent = "lighthouse"
+	AgentNimbus     Agent = "nimbus"
+	AgentTeku       Agent = "teku"
+	AgentPrysm      Agent = "prysm"
+	AgentLodestar   Agent = "lodestar"
+)
+
+var AllAgents = []Agent{
+	AgentUnknown,
+	AgentLighthouse,
+	AgentNimbus,
+	AgentTeku,
+	AgentPrysm,
+	AgentLodestar,
+}
+
+type AgentCount struct {
+	Unknown    int `json:"unknown"`
+	Lighthouse int `json:"lighthouse"`
+	Nimbus     int `json:"nimbus"`
+	Teku       int `json:"teku"`
+	Prysm      int `json:"prysm"`
+	Lodestar   int `json:"lodestar"`
+}
+
+func AgentFromString(agent string) Agent {
+	asLower := strings.ToLower(agent)
+
+	if strings.Contains(asLower, "lighthouse") {
+		return AgentLighthouse
+	}
+
+	if strings.Contains(asLower, "nimbus") {
+		return AgentNimbus
+	}
+
+	if strings.Contains(asLower, "teku") {
+		return AgentTeku
+	}
+
+	if strings.Contains(asLower, "prysm") {
+		return AgentPrysm
+	}
+
+	if strings.Contains(asLower, "lodestar") {
+		return AgentLodestar
+	}
+
+	return AgentUnknown
+}

--- a/pkg/exporter/consensus/api/types/agents_test.go
+++ b/pkg/exporter/consensus/api/types/agents_test.go
@@ -1,0 +1,27 @@
+package types
+
+import "testing"
+
+func TestAgentParsing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input  string
+		expect Agent
+	}{
+		{"Prysm/v2.0.2/4a4a7e97dfd2285a5e48a178f693d870e9a4ff60", AgentPrysm},
+		{"Lighthouse/v3.1.0-aa022f4/x86_64-linux", AgentLighthouse},
+		{"nimbus", AgentNimbus},
+		{"teku/teku/v22.9.0/linux-x86_64/-privatebuild-openjdk64bitservervm-java-17", AgentTeku},
+		{"Lodestar/v0.32.0-rc.0-1-gc3b5b6a9/linux-x64/nodejs", AgentLodestar},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			t.Parallel()
+			if actual := AgentFromString(test.input); actual != test.expect {
+				t.Errorf("Expected %s, got %s", test.expect, actual)
+			}
+		})
+	}
+}

--- a/pkg/exporter/consensus/api/types/peer.go
+++ b/pkg/exporter/consensus/api/types/peer.go
@@ -18,6 +18,11 @@ type Peer struct {
 	LastSeenP2PAddress string `json:"last_seen_p2p_address"`
 	State              string `json:"state"`
 	Direction          string `json:"direction"`
+	Agent              string `json:"agent"`
+}
+
+func (p *Peer) DeriveAgent() Agent {
+	return AgentFromString(p.Agent)
 }
 
 type Peers []Peer
@@ -63,4 +68,41 @@ func (p *Peers) ByStateAndDirection(state, direction string) Peers {
 	}
 
 	return peers
+}
+
+func (p *Peers) ByAgent(agent Agent) Peers {
+	var peers []Peer
+
+	for _, peer := range *p {
+		if peer.DeriveAgent() == agent {
+			peers = append(peers, peer)
+		}
+	}
+
+	return peers
+}
+
+func (p *Peers) AgentCount() AgentCount {
+	count := AgentCount{}
+
+	for _, agent := range AllAgents {
+		numberOfAgents := len(p.ByAgent(agent))
+
+		switch agent {
+		case AgentUnknown:
+			count.Unknown = numberOfAgents
+		case AgentLighthouse:
+			count.Lighthouse = numberOfAgents
+		case AgentNimbus:
+			count.Nimbus = numberOfAgents
+		case AgentTeku:
+			count.Teku = numberOfAgents
+		case AgentPrysm:
+			count.Prysm = numberOfAgents
+		case AgentLodestar:
+			count.Lodestar = numberOfAgents
+		}
+	}
+
+	return count
 }

--- a/pkg/exporter/consensus/metrics.go
+++ b/pkg/exporter/consensus/metrics.go
@@ -49,6 +49,7 @@ func NewMetrics(client eth2client.Service, ap api.ConsensusClient, beac beacon.N
 
 	prometheus.MustRegister(m.generalMetrics.NodeVersion)
 	prometheus.MustRegister(m.generalMetrics.Peers)
+	prometheus.MustRegister(m.generalMetrics.PeerAgents)
 
 	prometheus.MustRegister(m.syncMetrics.Percentage)
 	prometheus.MustRegister(m.syncMetrics.EstimatedHighestSlot)


### PR DESCRIPTION
Adds a new metric, `eth_con_peer_agents`, which contains the amount of remote peers for each beacon client implementation.

e.e.
```
eth_con_peer_agents{agent="lighthouse",ethereum_role="consensus",module="general",node_name="consensus-client"} 73
```

Note: It appears only `nimbus` has support for this metric. Other implementations don't return enough data in the `/eth/v1/node/peers` responses to derive this metric.