### PR TITLE
fix(consensus): Fetch finality checkpoints on a loop

### DIFF
--- a/pkg/exporter/consensus/beacon/state/fork_epoch.go
+++ b/pkg/exporter/consensus/beacon/state/fork_epoch.go
@@ -14,7 +14,7 @@ type ForkEpoch struct {
 
 // Active returns true if the fork is active at the given slot.
 func (f *ForkEpoch) Active(slot, slotsPerEpoch phase0.Slot) bool {
-	return phase0.Epoch(int(slot)/int(slotsPerEpoch)) > f.Epoch
+	return phase0.Epoch(int(slot)/int(slotsPerEpoch)) >= f.Epoch
 }
 
 // ForkEpochs is a list of forks that activate at specific epochs.

--- a/pkg/exporter/consensus/jobs/beacon.go
+++ b/pkg/exporter/consensus/jobs/beacon.go
@@ -210,7 +210,7 @@ func (b *Beacon) Start(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(time.Second * 30):
+		case <-time.After(time.Second * 60):
 			b.tick(ctx)
 		}
 	}

--- a/pkg/exporter/consensus/jobs/beacon.go
+++ b/pkg/exporter/consensus/jobs/beacon.go
@@ -210,14 +210,14 @@ func (b *Beacon) Start(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(time.Second * 5):
+		case <-time.After(time.Second * 30):
 			b.tick(ctx)
 		}
 	}
 }
 
 func (b *Beacon) tick(ctx context.Context) {
-
+	b.updateFinalizedCheckpoint(ctx)
 }
 
 func (b *Beacon) setupSubscriptions(ctx context.Context) error {
@@ -233,7 +233,14 @@ func (b *Beacon) setupSubscriptions(ctx context.Context) error {
 		return err
 	}
 
-	if _, err := b.beaconNode.OnFinalizedCheckpoint(ctx, b.handleFinalizedCheckpointEvent); err != nil {
+	if _, err := b.beaconNode.OnFinalizedCheckpoint(ctx, func(ctx context.Context, ev *v1.FinalizedCheckpointEvent) error {
+		// Sleep for 5 seconds to allow the beacon node to process the finalized checkpoint.
+		time.Sleep(3 * time.Second)
+
+		b.updateFinalizedCheckpoint(ctx)
+
+		return nil
+	}); err != nil {
 		return err
 	}
 

--- a/pkg/exporter/consensus/jobs/beacon.go
+++ b/pkg/exporter/consensus/jobs/beacon.go
@@ -234,7 +234,7 @@ func (b *Beacon) setupSubscriptions(ctx context.Context) error {
 	}
 
 	if _, err := b.beaconNode.OnFinalizedCheckpoint(ctx, func(ctx context.Context, ev *v1.FinalizedCheckpointEvent) error {
-		// Sleep for 5 seconds to allow the beacon node to process the finalized checkpoint.
+		// Sleep for 3 seconds to allow the beacon node to process the finalized checkpoint.
 		time.Sleep(3 * time.Second)
 
 		b.updateFinalizedCheckpoint(ctx)


### PR DESCRIPTION
This fixes a bug noticed by @remyroy where the finalized/justified epoch reported by the metrics exporter could be 1 epoch behind reality. The exporter listens for `finalized_checkpoint` events, and then _immediately_ fetches the head finality_checkpoint from the beacon node. This is usually fine, but in some cases the beacon node can take a little while to return the new checkpoint.

This fix adds a sleep of 3s when the event is received before firiing off the API request, and also just fetches the checkpoints on a loop every 60s.